### PR TITLE
OSGi classloading support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,4 +51,17 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-</project>
+	<build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.0</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  </project>

--- a/src/main/java/com/github/trevershick/test/ldap/LdapServerResource.java
+++ b/src/main/java/com/github/trevershick/test/ldap/LdapServerResource.java
@@ -25,7 +25,7 @@ public class LdapServerResource {
 
 	private InMemoryDirectoryServer server;
 	private LdapConfiguration config;
-	
+	private Class annotatedClass;
 
 	public LdapServerResource() {
 		this(null);
@@ -35,6 +35,8 @@ public class LdapServerResource {
 		this.config = annotated == null ? null : annotated.getClass().getAnnotation(LdapConfiguration.class);
 		if (this.config == null) {
 			this.config = defaultConfiguration();
+		} else {
+			annotatedClass = annotated.getClass();
 		}
 	}
 	
@@ -143,7 +145,8 @@ public class LdapServerResource {
 	protected void loadLdifFiles() throws Exception {
 		Iterable<String> ldifResources = ldifResources();
 		for (String ldif : ldifResources) {
-			InputStream resourceAsStream = getClass().getResourceAsStream(ldif);
+			Class clazz = (annotatedClass != null) ? annotatedClass : getClass();
+			InputStream resourceAsStream = clazz.getResourceAsStream(ldif);
 			if (resourceAsStream == null) {
 				throw new FileNotFoundException("Should be able to load " + ldif);
 			}


### PR DESCRIPTION
I've recently been using your excellent library to do some testing.  In attempting to use the library hosted inside of an Pax-Exam OSGi container, I ran into problems loading LDIF files because the call to getClass() is unable to "see" my test class.  This pull request is to allow for the annotated test class to be used for the classloader to pull in the LDIF files if it is found.  Otherwise, the original getClass() method is used.

It would be great if you could pull this into your code so I can avoid having to maintain it.

Craig
